### PR TITLE
Add check for substrings in hero-search

### DIFF
--- a/client/js/utils.js
+++ b/client/js/utils.js
@@ -1085,7 +1085,8 @@ function similarity(s1, s2) {
     if (longerLength == 0) {
       return 1.0;
     }
-    return (longerLength - editDistance(longer, shorter)) / parseFloat(longerLength);
+    var isSub = (longer.toLowerCase().indexOf(shorter.toLowerCase()) !== -1)?1:0; //check whether
+    return (longerLength - editDistance(longer, shorter)) / parseFloat(longerLength) + isSub;
 }
 
 function editDistance(s1, s2) {


### PR DESCRIPTION
Closes #18.

The search will now prioritize heroes whose name is a sub- or
superstring of the searched string.

Previously heroes were ranked by similarity between the name and the searched term. If you just typped the first couple letters, this yields a pretty low values (and the hero might not be shown).
Now sub/superstrings are always ranked on top. Similarity is still used to rank inside those two categories (is sub/superstring; is no sub/superstring).

This might be controversial, as it is not just a plain bug fix, but I believe it is an improvement.