### PR TITLE
Close daily event and show popup, if none is active.

### DIFF
--- a/client/js/game.js
+++ b/client/js/game.js
@@ -12378,7 +12378,7 @@ function Game() {
         } else {
         	this.doAction("doDaily", false);
             popup={
-                    text:"Congratulations, you've finished todays event.",
+                    text:"Congratulations, you've finished today's event.",
                     mode:"alert",
                 }
         }

--- a/client/js/game.js
+++ b/client/js/game.js
@@ -12375,7 +12375,12 @@ function Game() {
                     ctx.restore();
                 }  
             }
-
+        } else {
+        	this.doAction("doDaily", false);
+            popup={
+                    text:"Congratulations, you've finished todays event.",
+                    mode:"alert",
+                }
         }
     }
     this.drawFlash = function (ctx) {


### PR DESCRIPTION
Deals with #44
When the game would have "freezed" normally it now closes the
event-window and shows a generic "congratulations"-popup (figuring out
which event just finished requires further work and won't be seen often
anyways).