### PR TITLE
Fix histroy display for tournaments

### DIFF
--- a/client/js/game.js
+++ b/client/js/game.js
@@ -13495,16 +13495,7 @@ function Game() {
                 } else if (action=="[G.A.M.E.S]") {
                     text(ctx,mdata.log[i].msg,W*0.5-bgw*0.5*0.9+120,H*0.23+line*H*0.05,"24px"+FONT,"black","left","middle");
                 } else if (action=="Registered") {
-                    var found=undefined;
-                    var pos=mdata.log[i].msg.length-4;
-                    while(found==undefined) {
-                        if (mdata.log[i].msg[pos]==" ") found=pos;
-                        else --pos;
-                    }
-                    found = mdata.log[i].msg.length-found-1;
-                    var l=found-3;
-                    var val=mdata.log[i].msg.substr(mdata.log[i].msg.length-found,l);
-                    text(ctx,"Succesfully registered into a Tournament. Enter cost is "+val+" UM.",W*0.5-bgw*0.5*0.9+120,H*0.23+line*H*0.05,"24px"+FONT,"black","left","middle");
+                    text(ctx,mdata.log[i].msg,W*0.5-bgw*0.5*0.9+120,H*0.23+line*H*0.05,"24px"+FONT,"black","left","middle");
                 } else if (action=="Fight") {
                     var found=undefined;
                     var pos=mdata.log[i].msg.length-8;

--- a/scripts/cloudScript.js
+++ b/scripts/cloudScript.js
@@ -3137,7 +3137,7 @@ handlers.etregister = function (args, context) {
         var ret=registerT2(name,currentPlayerId,args.setup,args.kid);
         if (ret===true) {
             //data.city.pass.tournaments+=1;
-            log("Registered to extra tournament paying");
+            log("Registered to extra tournament (T2).");
             return {ok:true};
         } else return { ok: false, err: ret};
     } else return { ok: false, err: "Server error"};


### PR DESCRIPTION
I don't understand why one would try to parse the messages for entry
cost in the first place (as they are good enough to show: "Registered to
tournament paying 0 UM") and it breaks on T2...