### PR TITLE
Fix dungeon level and multiline text

### DIFF
--- a/client/js/utils.js
+++ b/client/js/utils.js
@@ -234,7 +234,6 @@ function etext(ctx,rtext,x,y,font,fill,align,valign,stroke,strokeWidth,space,dis
         } else {
             text2draw.push(ltext);
             ltext = "";
-            index++;
         }
     }
     if (ltext !== "") text2draw.push(ltext);

--- a/website/api.php
+++ b/website/api.php
@@ -1045,7 +1045,7 @@ if (isset($_POST["action"])) {
                     $sql->query("UPDATE dungeon SET `level`= $lvl WHERE eid = $eid AND `uid`='$uid' LIMIT 1");
                     $prize = json_encode(array("SD"=>2500*$wins));
                     $sql->query("INSERT INTO `prizes` (`id`, `tries`, `status`, `created`, `uid`, `prize`) VALUES (NULL, '0', '0', CURRENT_TIMESTAMP, '$uid', '$prize');");
-					--$lvl; //decrease lvl to send back the level actually fought and not the next one
+					if ($bres == 1) --$lvl; //decrease lvl to send back the level actually fought and not the next one
                 }
                 echo json_encode(array("success"=>true,"data"=>array(
                     "enemy"=> "Dungeon Floor[$lvl]",


### PR DESCRIPTION
If a fight-max ends with a win level should be reduced by one to send
the level of the fight shown, if it ends with a loss this is not needed.

Also fixes multiline-text (#126).